### PR TITLE
SDEV-3246 - allow user to override resource allocation

### DIFF
--- a/fastq_to_TMB_processes.nf
+++ b/fastq_to_TMB_processes.nf
@@ -285,7 +285,7 @@ process manta {
             --referenceFasta=${reference}  \
             --runDir Manta
 
-        python Manta/runWorkflow.py -m local -j 16
+        python Manta/runWorkflow.py -m local -j 48
 
         mv Manta/results/variants/candidateSmallIndels.vcf.gz \
             Manta_${patient}_${T}_vs_${N}.candidateSmallIndels.vcf.gz

--- a/fastq_to_TMB_processes.nf
+++ b/fastq_to_TMB_processes.nf
@@ -114,7 +114,6 @@ process countCdsBases {
 
 process trimPair {
     tag "$an_id"
-    cpus 10
 
     input:
         tuple val(an_id), val(patient), val(tissue), path(reads1), path(reads2)
@@ -140,8 +139,6 @@ process trimPair {
 
 process alignReads {
     tag "$an_id"
-    cpus 48
-    memory '48 GB'
 
     input:
         tuple val(an_id), val(patient), val(tissue), path(trim1), path(trim2)
@@ -162,7 +159,6 @@ process alignReads {
 
 process sortBam {
     tag "$an_id"
-    cpus 10
 
     input:
         tuple val(an_id), val(patient), val(tissue), path(bam_file)
@@ -178,8 +174,6 @@ process sortBam {
 
 process mergeBams {
     tag "${patient}_${tissue}"
-    memory "64 GB"
-    cpus 16
 
     input:
         tuple val(patient), val(tissue), val(an_id), path(bams_to_merge)
@@ -196,8 +190,6 @@ process mergeBams {
 process markDuplicates {
     tag "${patient}_${tissue}"
     publishDir "${params.out_dir}/bams/${patient}_bams"
-    memory '128 GB'
-    cpus 8
 
     input:
         tuple val(patient), val(tissue), path(bam_file)
@@ -222,7 +214,6 @@ process markDuplicates {
 process msiSensor2 {
     tag "${patient}_${T}_${N}"
     publishDir "${params.out_dir}/${patient}_${T}_${N}/MSIsensor2"
-    cpus 32
 
     input:
         tuple val(patient),
@@ -247,7 +238,6 @@ process msiSensor2 {
             -t ${T_bam} \
             -n ${N_bam} \
             -d /usr/TMB/msisensor2/models_b37_HumanG1Kv37/1030c0aa35ca5c263daeae866ad18632 \
-            -b 32 \
             -o msisensor2_${patient}_${T}_${N}.txt 2> msisensor2_out_${patient}_${T}_${N}.log
         """
 }
@@ -259,7 +249,6 @@ process msiSensor2 {
 process manta {
     tag "${patient}_${T}_${N}"
     publishDir "${params.out_dir}/${patient}_${T}_${N}/Manta"
-    cpus 48
 
     input:
         tuple val(patient),
@@ -296,7 +285,7 @@ process manta {
             --referenceFasta=${reference}  \
             --runDir Manta
 
-        python Manta/runWorkflow.py -m local -j 48
+        python Manta/runWorkflow.py -m local -j 16
 
         mv Manta/results/variants/candidateSmallIndels.vcf.gz \
             Manta_${patient}_${T}_vs_${N}.candidateSmallIndels.vcf.gz
@@ -316,7 +305,6 @@ process manta {
 process strelka {
     tag "${patient}_${T}_${N}"
     publishDir "${params.out_dir}/${patient}_${T}_${N}/strelka"
-    cpus 48
 
     input:
         tuple val(tool),
@@ -412,8 +400,6 @@ process createPassVcfsStrelka {
 process rtgIntersectCalls {
     tag "${patient}_${T}_${N}"
     publishDir "${params.out_dir}/${patient}_${T}_${N}/variant_intersect", mode: 'copy'
-    cpus 10
-    memory '16 GB'
 
     input:
         tuple val(patient),
@@ -497,7 +483,6 @@ process rtgIntersectCalls {
 process annotateSmallVariants {
     tag "${patient}_${T}_${N}"
     publishDir "${params.out_dir}/${patient}_${T}_${N}/annotated_variants", mode: 'copy'
-    memory '48 GB'
 
     input:
         tuple val(names),
@@ -581,7 +566,6 @@ process createPanelReport {
     publishDir "${params.out_dir}/${patient}_${T}_${N}/report", mode: 'copy', overwrite: true
     // occasionally there are zero variants, creating a div-by-0 error below.
     errorStrategy 'ignore'
-    memory '48 GB'
 
     input:
         path base_count

--- a/fastq_to_TMB_processes.nf
+++ b/fastq_to_TMB_processes.nf
@@ -168,7 +168,7 @@ process sortBam {
 
     script:
         """
-        /usr/TMB/samtools sort -@ 10 -T . -o ${bam_file.baseName}.sorted.bam ${bam_file}
+        /usr/TMB/samtools sort -@ $task.cpus -T . -o ${bam_file.baseName}.sorted.bam ${bam_file}
         """
 }
 
@@ -203,7 +203,7 @@ process markDuplicates {
     script:
         """
         sambamba markdup \
-            --nthreads 8 \
+            --nthreads $task.cpus \
             --tmpdir . \
             --hash-table-size 5000000 \
             --overflow-list-size 5000000 \
@@ -238,6 +238,7 @@ process msiSensor2 {
             -t ${T_bam} \
             -n ${N_bam} \
             -d /usr/TMB/msisensor2/models_b37_HumanG1Kv37/1030c0aa35ca5c263daeae866ad18632 \
+            -b $task.cpus \
             -o msisensor2_${patient}_${T}_${N}.txt 2> msisensor2_out_${patient}_${T}_${N}.log
         """
 }
@@ -285,7 +286,7 @@ process manta {
             --referenceFasta=${reference}  \
             --runDir Manta
 
-        python Manta/runWorkflow.py -m local -j 48
+        python Manta/runWorkflow.py -m local -j $task.cpus
 
         mv Manta/results/variants/candidateSmallIndels.vcf.gz \
             Manta_${patient}_${T}_vs_${N}.candidateSmallIndels.vcf.gz

--- a/mutect2_processes.nf
+++ b/mutect2_processes.nf
@@ -4,7 +4,6 @@
  */
 process mutect2 {
     tag "${patient}_${T}_${N}_${chromosome}_${start}_${end}"
-    cpus 4 // seems to use about 400% CPU per job
 
     input:
         tuple val(patient),

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,9 +11,21 @@ process {
   executor = 'slurm'
   queue = 'upgrade'
 
-  // to be compatible with executors that require a cpu and RAM request for all jobs
+  // default resource allocation
   cpus = 8
-  memory = '48 GB'
+  memory = 48.GB
+
+  // process-specific resource allocation (overrides defaults)
+  withName: alignReads { cpus = 48 }
+  withName: manta { cpus = 48 }
+  withName: markDuplicates { memory = 128.GB }
+  withName: mergeBams { cpus = 16; memory = 64.GB }
+  withName: msiSensor2 { cpus = 32 }
+  withName: 'mutect2Wf:mutect2' { cpus = 4 }
+  withName: rtgIntersectCalls { cpus = 10; memory = 16.GB }
+  withName: sortBam { cpus = 10 }
+  withName: strelka { cpus = 48 }
+  withName: trimPair { cpus = 10 }
 }
 
 // to make this extendable to other references in the future


### PR DESCRIPTION
Removes hardcoded threads/cpus from process definitions and moves all cpu/memory to nextflow.config to make it easier for users to override, if need be.