### PR TITLE
SDEV-3555 - remove 'java -jar' from snpsift var

### DIFF
--- a/mutect2_processes.nf
+++ b/mutect2_processes.nf
@@ -1,3 +1,6 @@
+// shorthand to run SnpSift in the container
+snpSift='/usr/TMB/snpEff/SnpSift.jar'
+
 /*
  * This is the main job that runs Mutect2 calling. It is set up to run on a specific region defined
  * by chromosome, start, and end.
@@ -164,7 +167,7 @@ process createPassVcfs {
 
     script:
         """
-        java -Xmx${task.memory.toGiga()}G -jar /usr/TMB/snpEff/SnpSift.jar filter \
+        java -Xmx${task.memory.toGiga()}G -jar ${snpSift} filter \
             "(FILTER = 'PASS')" \
             ${vcf_file} \
             > ${patient}_${T}_${N}.PASS.vcf

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,4 +1,4 @@
-params.release = '2.2.8'
+params.release = '2.2.9'
 
 singularity {
   enabled = true


### PR DESCRIPTION
Bugfix for SDEV-3555 where the command to run SnpSift in some processes comes out as `java -jar java -jar SnpSift`.